### PR TITLE
Make Updown Testing workflow to run only with code changes

### DIFF
--- a/.github/workflows/node-frontend.yml
+++ b/.github/workflows/node-frontend.yml
@@ -1,6 +1,6 @@
 name: Docker Hub Push
 
-run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
+run-name: ${{ github.actor }} is Pushing Node Frontend Docker Image 🚀
 
 on:
   push:

--- a/.github/workflows/run-test-updown-investing.yml
+++ b/.github/workflows/run-test-updown-investing.yml
@@ -1,14 +1,35 @@
-name: CI
+name: Updown Investing Server testing via docker build
 
 on:
   pull_request:
-    branches: [ "*" ]
+    - main
 
 env:
   TEST_TAG: user/app:test
   LATEST_TAG: user/app:latest
 
 jobs:
+  check-if-files-has-changed:
+    runs-on: ubuntu-latest
+    name: Check If files as changed in Updown Investing Project
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files in the incubator/updown-investing folder
+        id: changed-files-specific
+        uses: tj-actions/changed-files@v34
+        with:
+          files: |
+            'incubator/updown-investing/**'
+            '.github/worksflow/run-test-updown-investing.yml'
+
+      - name: Stop if there is no changed files
+        if: steps.changed-files-specific.outputs.any_changed == 'false'
+        run: exit 1
+
+
   updown-investing-ci-quality-check:
     env:
       working-directory: ./incubator/updown-investing

--- a/.github/workflows/run-test-updown-investing.yml
+++ b/.github/workflows/run-test-updown-investing.yml
@@ -2,35 +2,16 @@ name: Updown Investing Server testing via docker build
 
 on:
   pull_request:
-    branches:
-      - 'main'
+    paths:
+      - "incubator/updown-investing/**"
+      - ".github/workflows/run-test-updown-investing.yml"
+
 
 env:
   TEST_TAG: user/app:test
   LATEST_TAG: user/app:latest
 
 jobs:
-  check-if-files-has-changed:
-    runs-on: ubuntu-latest
-    name: Check If files as changed in Updown Investing Project
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
-
-      - name: Get changed files in the incubator/updown-investing folder
-        id: changed-files-specific
-        uses: tj-actions/changed-files@v34
-        with:
-          files: |
-            incubator/updown-investing/**
-            .github/worksflow/run-test-updown-investing.yml
-
-      - name: Stop if there is no changed files
-        if: steps.changed-files-specific.outputs.any_changed == 'false'
-        run: exit 1
-
-
   updown-investing-ci-quality-check:
     env:
       working-directory: ./incubator/updown-investing

--- a/.github/workflows/run-test-updown-investing.yml
+++ b/.github/workflows/run-test-updown-investing.yml
@@ -2,10 +2,8 @@ name: Updown Investing Server testing via docker build
 
 on:
   pull_request:
-    - main
-  push:
     branches:
-      - [ "*" ]
+      - 'main'
 
 env:
   TEST_TAG: user/app:test
@@ -24,9 +22,9 @@ jobs:
         id: changed-files-specific
         uses: tj-actions/changed-files@v34
         with:
-          files: |
-            'incubator/updown-investing/**'
-            '.github/worksflow/run-test-updown-investing.yml'
+          files:
+            - 'incubator/updown-investing/**'
+            - '.github/worksflow/run-test-updown-investing.yml'
 
       - name: Stop if there is no changed files
         if: steps.changed-files-specific.outputs.any_changed == 'false'

--- a/.github/workflows/run-test-updown-investing.yml
+++ b/.github/workflows/run-test-updown-investing.yml
@@ -22,9 +22,9 @@ jobs:
         id: changed-files-specific
         uses: tj-actions/changed-files@v34
         with:
-          files:
-            - 'incubator/updown-investing/**'
-            - '.github/worksflow/run-test-updown-investing.yml'
+          files: |
+            incubator/updown-investing/**
+            .github/worksflow/run-test-updown-investing.yml
 
       - name: Stop if there is no changed files
         if: steps.changed-files-specific.outputs.any_changed == 'false'

--- a/.github/workflows/run-test-updown-investing.yml
+++ b/.github/workflows/run-test-updown-investing.yml
@@ -3,6 +3,9 @@ name: Updown Investing Server testing via docker build
 on:
   pull_request:
     - main
+  push:
+    branches:
+      - [ "*" ]
 
 env:
   TEST_TAG: user/app:test

--- a/.github/workflows/run-test-updown-investing.yml
+++ b/.github/workflows/run-test-updown-investing.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Get changed files in the incubator/updown-investing folder
         id: changed-files-specific


### PR DESCRIPTION
- fix: Change run-name of node-frontend workflow
- feat: Make updown-investing run only when there is change in code.
